### PR TITLE
Replace MCPServer with DBConfig in tests

### DIFF
--- a/tests/test_mssql.py
+++ b/tests/test_mssql.py
@@ -2,10 +2,10 @@ import sys
 import os
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from src.mssql.server import MCPServer
+from src.mssql.server import DBConfig
 
 def test_connection():
-    server = MCPServer()
+    server = DBConfig()
     try:
         conn = server.get_connection()
         print("✓ Database connection successful")


### PR DESCRIPTION
Now test_mssql.py can be run with :
python test_mssql.py